### PR TITLE
Add Grafana deployment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,7 @@ jobs:
           kubectl diff -f .k8s/mongo.yaml || true
           kubectl diff -f .k8s/opensearch.yaml || true
           kubectl diff -f .k8s/graylog.yaml || true
+          kubectl diff -f .k8s/grafana.yaml || true
           kubectl diff -f .k8s/cert.yaml || true
 
       - name: Apply manifests
@@ -53,4 +54,5 @@ jobs:
           kubectl apply -f .k8s/mongo.yaml
           kubectl apply -f .k8s/opensearch.yaml
           kubectl apply -f .k8s/graylog.yaml
+          kubectl apply -f .k8s/grafana.yaml
           kubectl apply -f .k8s/cert.yaml

--- a/.k8s/grafana.yaml
+++ b/.k8s/grafana.yaml
@@ -1,0 +1,121 @@
+# Deploy:
+#   kubectl apply -f .k8s/grafana.yaml
+#
+# Verify:
+#   kubectl get pods -n game-library-infra -l app=grafana
+#   kubectl logs -n game-library-infra deployment/grafana
+#
+# Test connectivity (from within cluster):
+#   kubectl run -it --rm curl --image=curlimages/curl --namespace=game-library-infra \
+#     -- curl http://grafana-service:3000/api/health
+#
+# =============================================================================
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: grafana-pvc
+  namespace: game-library-infra
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: grafana
+  namespace: game-library-infra
+  labels:
+    app: grafana
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+        - name: grafana
+          image: grafana/grafana:13.0.0-23336907879-ubuntu
+          ports:
+            - name: grafana
+              containerPort: 3000
+          env:
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-secret
+                  key: grafana-admin-password
+            - name: GF_ANALYTICS_REPORTING_ENABLED
+              value: "false"
+            - name: GF_ANALYTICS_CHECK_FOR_UPDATES
+              value: "false"
+            - name: GF_ANALYTICS_CHECK_FOR_PLUGIN_UPDATES
+              value: "false"
+            - name: GF_NEWS_NEWS_FEED_ENABLED
+              value: "false"
+          volumeMounts:
+            - name: grafana-storage-volume
+              mountPath: /var/lib/grafana
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: grafana
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: grafana
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      volumes:
+        - name: grafana-storage-volume
+          persistentVolumeClaim:
+            claimName: grafana-pvc
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: grafana-service
+  namespace: game-library-infra
+spec:
+  selector:
+    app: grafana
+  ports:
+    - protocol: TCP
+      name: grafana
+      port: 3000
+      targetPort: grafana
+---
+kind: Ingress
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: grafana-ingress
+  namespace: game-library-infra
+  annotations:
+    cert-manager.io/cluster-issuer: lets-encrypt-dns
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - grafana._DOMAIN_
+      secretName: grafana-tls
+  rules:
+    - host: grafana._DOMAIN_
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: grafana-service
+                port:
+                  name: grafana

--- a/.k8s/grafana.yaml
+++ b/.k8s/grafana.yaml
@@ -76,6 +76,13 @@ spec:
               port: grafana
             initialDelaySeconds: 5
             periodSeconds: 5
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "300m"
       volumes:
         - name: grafana-storage-volume
           persistentVolumeClaim:

--- a/.k8s/graylog.yaml
+++ b/.k8s/graylog.yaml
@@ -98,6 +98,13 @@ spec:
           volumeMounts:
             - name: graylog-data
               mountPath: /usr/share/graylog/data/journal
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "100m"
+            limits:
+              memory: "1Gi"
+              cpu: "400m"
       volumes:
         - name: graylog-data
           persistentVolumeClaim:

--- a/.k8s/jaeger.yaml
+++ b/.k8s/jaeger.yaml
@@ -68,6 +68,13 @@ spec:
               port: 13133
             initialDelaySeconds: 5
             periodSeconds: 5
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "300m"
       volumes:
         - name: jaeger-ui-config-volume
           configMap:

--- a/.k8s/mongo.yaml
+++ b/.k8s/mongo.yaml
@@ -58,6 +58,13 @@ spec:
           volumeMounts:
             - name: mongo-data
               mountPath: /data/db
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "384Mi"
+              cpu: "300m"
       volumes:
         - name: mongo-data
           persistentVolumeClaim:

--- a/.k8s/opensearch.yaml
+++ b/.k8s/opensearch.yaml
@@ -55,8 +55,12 @@ spec:
             - configMapRef:
                 name: opensearch-config
           resources:
+            requests:
+              memory: "512Mi"
+              cpu: "100m"
             limits:
-              memory: 1Gi
+              memory: "1280Mi"
+              cpu: "400m"
           volumeMounts:
             - name: opensearch-data
               mountPath: /usr/share/opensearch/data

--- a/.k8s/prometheus.yaml
+++ b/.k8s/prometheus.yaml
@@ -114,6 +114,13 @@ spec:
               port: prometheus
             initialDelaySeconds: 5
             periodSeconds: 5
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "100m"
+            limits:
+              memory: "128Mi"
+              cpu: "300m"
       volumes:
         - name: prometheus-config-volume
           configMap:

--- a/.k8s/secrets.yaml
+++ b/.k8s/secrets.yaml
@@ -27,6 +27,16 @@ data:
   # echo -n "mongodb://<username>:<password>@mongo-service:27017/graylog?authSource=admin" | base64
   graylog-mongodb-uri: ""
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-secret
+  namespace: game-library-infra
+type: Opaque
+data:
+  # echo -n "<admin-password>" | base64
+  grafana-admin-password: ""
+---
 # Cloudflare API token for DNS-01 cert challenge (used by lets-encrypt-dns ClusterIssuer).
 # Token permissions and full info - https://cert-manager.io/docs/configuration/acme/dns01/cloudflare/
 kind: Secret

--- a/.k8s/zipkin.yaml
+++ b/.k8s/zipkin.yaml
@@ -48,6 +48,13 @@ spec:
               port: zipkin
             initialDelaySeconds: 5
             periodSeconds: 5
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "300m"
 ---
 kind: Service
 apiVersion: v1

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: zipkin jaeger graylog prometheus all stop clean run-example
+.PHONY: zipkin jaeger graylog prometheus grafana all stop clean run-example
 
 # Start Zipkin
 zipkin:
@@ -15,6 +15,10 @@ graylog:
 # Start Prometheus
 prometheus:
 	docker compose up -d prometheus
+
+# Start Grafana
+grafana:
+	docker compose up -d grafana
 
 # Start all services
 all:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Infrastructure services for [game-library](https://github.com/OutOfStack/game-li
 | **Jaeger** | Distributed tracing system with native OTLP support |
 | **Graylog** | Log management platform (with MongoDB and OpenSearch) |
 | **Prometheus** | Metrics collection and monitoring |
+| **Grafana** | Metrics visualization and dashboards |
 
 ## Quick Start with Docker
 
@@ -22,6 +23,7 @@ make zipkin
 make jaeger
 make prometheus
 make graylog
+make grafana
 
 # Stop all services
 make stop
@@ -39,6 +41,7 @@ make clean
 | Prometheus | http://localhost:9090 | No authentication required |
 | Graylog | http://localhost:9000 | `admin:admin` |
 | OpenSearch | http://localhost:9200 | No authentication (security disabled) |
+| Grafana | http://localhost:3000 | `admin:admin` |
 
 ## Graylog Setup
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,6 +110,21 @@ services:
       - source: prometheus_config
         target: /etc/prometheus/prometheus.yml
 
+  grafana:
+    container_name: grafana
+    image: grafana/grafana:13.0.0-23336907879-ubuntu
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_ANALYTICS_REPORTING_ENABLED=false
+      - GF_ANALYTICS_CHECK_FOR_UPDATES=false
+      - GF_ANALYTICS_CHECK_FOR_PLUGIN_UPDATES=false
+      - GF_NEWS_NEWS_FEED_ENABLED=false
+    volumes:
+      - grafana_data:/var/lib/grafana
+    restart: always
+
 volumes:
   mongo_data:
     driver: local
@@ -118,6 +133,8 @@ volumes:
   graylog_data:
     driver: local
   prometheus_data:
+    driver: local
+  grafana_data:
     driver: local
     
 configs:


### PR DESCRIPTION
* **Grafana Deployment**: Introduced Kubernetes manifests for deploying Grafana, including a PersistentVolumeClaim, Deployment, Service, and Ingress, enabling metrics visualization within the cluster.
* **Docker Compose Integration**: Added a Grafana service to `docker-compose.yml`, allowing local development and testing of Grafana alongside other infrastructure services.
* **Configuration and Documentation Updates**: Updated the `Makefile` with a `grafana` target and integrated it into the `all` target, and revised the `README.md` to document Grafana's inclusion, quick start, and access details.
* **Secret Management**: Added a placeholder secret definition in `.k8s/secrets.yaml` for managing the Grafana administrator password securely.